### PR TITLE
Image layout improvements

### DIFF
--- a/components/blocks/copyright-image.tsx
+++ b/components/blocks/copyright-image.tsx
@@ -22,19 +22,19 @@ export const CopyrightImage = ({ data }) => {
     <Section color={data.color}>
       <Container
         size="small"
-        className="grid grid-cols-1 lg:grid-cols-1 gap-x-10 gap-y-0 items-center justify-center"
+        className="grid grid-cols-1 lg:grid-cols-1 gap-x-10 gap-y-0 items-center justify-center py-0"
       >
         <div className="lg:col-start-1 lg:col-end-1 text-center lg:text-center">
           {data.image && (
             <div className="row-start-1 flex justify-center">
               <img
-                className="w-full max-w-xs lg:max-w-none h-auto"
+                className="object-cover w-full h-full"
                 alt={data.image.alt}
                 src={data.image.src}
               />
             </div>
           )}
-          {data.attribution && <Markdown>{data.attribution}</Markdown>}
+          {data.attribution && <div className="absolute w-full py-2.5 bottom-0 inset-x-0 text-white text-xs text-center leading-4"><Markdown>{data.attribution}</Markdown></div>}
         </div>
       </Container>
     </Section>

--- a/components/blocks/hero.tsx
+++ b/components/blocks/hero.tsx
@@ -22,7 +22,7 @@ export const Hero = ({ data }) => {
     <Section color={data.color}>
       <Container
         size="large"
-        className="grid grid-cols-1 lg:grid-cols-3 gap-x-10 gap-y-8 items-center justify-center"
+        className="grid grid-cols-1 lg:grid-cols-3 gap-x-10 gap-y-8 items-center justify-center py-0"
       >
         <div className="row-start-2 lg:row-start-1 lg:col-start-1 lg:col-end-3 text-center lg:text-left">
           {data.tagline && (


### PR DESCRIPTION
- copyright images take up full height of block and render attribution over top
- remove vertical padding on hero blocks